### PR TITLE
"NixOS Gem Mismatch" lock gems without installing

### DIFF
--- a/_posts/2025-03-05-nixos-gem-mismatch.html
+++ b/_posts/2025-03-05-nixos-gem-mismatch.html
@@ -2,7 +2,7 @@
 layout:          post
 title:           NixOS Ruby on Rails Gem Mismatches
 date:            2025-03-05 22:00:00
-updated:         2025-03-06 10:00:00
+updated:         2025-03-22 20:00:00
 description:     Dealing with platform-specific gems in a Nix development environment.
 ---
 
@@ -65,7 +65,7 @@ PLATFORMS
   <li>Ensure a Clean Slate: Exit any existing Nix development shells. <kbd>echo $SHLVL</kbd> should be 1. Though I’m not sure it’s essential, it helps prevent potential conflicts from nested environments.</li>
   <li>Create a Temporary Bundler Environment: Run <kbd>nix-shell -p ruby_3_4 -p bundler -p bundix</kbd> to set up a temporary environment with the necessary Ruby, Bundler, and Bundix tools.</li>
   <li>Update the Gemfile: Add the new gem or modify existing gems in your Gemfile as you normally would.</li>
-  <li>Update Gemfile.lock and gemset.nix: Execute <kbd>BUNDLE_FORCE_RUBY_PLATFORM="true" bundle update; bundix</kbd> to update Gemfile.lock with the new or modified gems and generate the updated gemset.nix with the correct hashes.</li>
+  <li>Update Gemfile.lock and gemset.nix: Execute <kbd>BUNDLE_FORCE_RUBY_PLATFORM="true" bundle lock --update; bundix</kbd> to update Gemfile.lock with the new or modified gems and generate the updated gemset.nix with the correct hashes.</li>
   <li>Exit the Temporary Environment: Close the nix-shell.</li>
   <li>Start the Development Environment: Run <kdb>nix develop</kbd> to apply the changes and install the updated gems.</li>
 </ol>


### PR DESCRIPTION
Thanks for this article! It is timely as I just ran into this.

I had a problem with updating `Gemfile.lock` and had to make a change to the process. I thought I'd send a PR over because it seems potentially useful in general.

---

`bundle update` updates the lock fine *and* installs the new gems. This can be problematic if necessary headers or dependencies are not installed on the
system, which is likely with NixOS where headers are not generally provided globally.

`bundle lock --update` performs a lock, which
correctly sets the ruby PLATFORMS, without installing.

https://stackoverflow.com/questions/26335777/updating-gemfile-lock-without-installing-gems

This resolved issues locking on my machine.